### PR TITLE
Add badges, continuous integeration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: julia
+os:
+  - linux
+julia:
+  - release
+  - nightly
+notifications:
+  email: false
+script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("DecisionTree"); Pkg.test("DecisionTree"; coverage=true)'
+after_success:
+  - julia -e 'cd(Pkg.dir("DecisionTree")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # DecisionTree.jl
 
+[![Build Status](https://travis-ci.org/bensadeghi/DecisionTree.jl.svg?branch=master)](https://travis-ci.org/bensadeghi/DecisionTree.jl)
+[![Coverage Status](https://coveralls.io/repos/bensadeghi/DecisionTree.jl/badge.svg?branch=master)](https://coveralls.io/r/bensadeghi/DecisionTree.jl?branch=master)
+[![DecisionTree](http://pkg.julialang.org/badges/DecisionTree_release.svg)](http://pkg.julialang.org/?pkg=DecisionTree&ver=release)
+
 Decision Tree Classifier and Regressor in Julia
 
 Implementation of the [ID3 algorithm](http://en.wikipedia.org/wiki/ID3_algorithm)


### PR DESCRIPTION
Hi @bensadeghi 

I really like this package, and I thought it might be nice to add these "badges", and enable TravisCI and Coveralls (for code coverage reporting). Apart from the utility of these services themselves, there is also the "signal" they send that this package is in excellent condition.

I can't enable these services myself, but with this PR all you should have to do is turn them on and it should all "just work"