### PR TITLE
Improved learning speed

### DIFF
--- a/src/regression.jl
+++ b/src/regression.jl
@@ -20,8 +20,12 @@ function _split_mse{T<:Float64, U<:Real}(labels::Vector{T}, features::Matrix{U},
         features_i = features[ord,i]
         labels_i = labels[ord]
         if nr > 100
-            domain_i = quantile(features_i, linspace(0.01, 0.99, 99);
-                                sorted=true)
+            if VERSION >= v"0.4.0-dev"
+                domain_i = quantile(features_i, linspace(0.01, 0.99, 99);
+                                    sorted=true)
+            else  # sorted=true isn't supported on StatsBase's Julia 0.3 version
+                domain_i = quantile(features_i, linspace(0.01, 0.99, 99))
+            end
         else
             domain_i = features_i
         end

--- a/src/regression.jl
+++ b/src/regression.jl
@@ -20,7 +20,8 @@ function _split_mse{T<:Float64, U<:Real}(labels::Vector{T}, features::Matrix{U},
         features_i = features[ord,i]
         labels_i = labels[ord]
         if nr > 100
-            domain_i = quantile(features_i, linspace(0.01, 0.99, 99))
+            domain_i = quantile(features_i, linspace(0.01, 0.99, 99);
+                                sorted=true)
         else
             domain_i = features_i
         end
@@ -34,7 +35,14 @@ function _split_mse{T<:Float64, U<:Real}(labels::Vector{T}, features::Matrix{U},
     return best
 end
 
+""" Finds the threshold to split `features` with that minimizes the
+mean-squared-error loss over `labels`.
+
+Returns (best_val, best_thresh), where `best_val` is -MSE """
 function _best_mse_loss{T<:Float64, U<:Real}(labels::Vector{T}, features::Vector{U}, domain)
+    # True, but costly assert. However, see
+    # https://github.com/JuliaStats/StatsBase.jl/issues/164
+    # @assert issorted(features) && issorted(domain) 
     best_val = -Inf
     best_thresh = 0.0
     s_l = s2_l = zero(T)
@@ -43,7 +51,6 @@ function _best_mse_loss{T<:Float64, U<:Real}(labels::Vector{T}, features::Vector
     nl = 0
     n = length(labels)
     i = 1
-    # @assert issorted(features)  # true, but costly assert
     # Because the `features` are sorted, below is an O(N) algorithm for finding
     # the optimal threshold amongst `domain`. We simply iterate through the
     # array and update s_l and s_r (= sum(labels) - s_l) as we go. - @cstjean


### PR DESCRIPTION
I replaced the O(N^2) threshold selection algorithm with an O(N) version. On my benchmark,

```julia
using Benchmarks
Profile.clear()
srand(2)
N = 3000
X = randn(N, 10)
y = randn(N)

model = fit!(DecisionTree.RandomForestRegressor(), X, y)
@benchmark fit!(DecisionTree.RandomForestRegressor(), X, y)
```

it is twice as fast as `master`. It should be mathematically exactly the same as before, but there's a handful of branches that are different. I blame floating point inaccuracy... but I'm not so sure.... the computation for `s_r` and `s2_r` is not floating-point-equivalent, so presumably over all the comparisons that DecisionTree makes in fitting a tree, it can make a difference at some point? All tests pass, but please review carefully.

I took `for thresh in domain[2:end]` from your code and kept it there, but I'm not sure that I see the reasoning for starting at 2, especially when `domain` comes from `quantile`. Could you explain it please?

PS. sorry for the github noise, I've been struggling to get this PR accepted by github.