### PR TITLE
Added the maxdepth parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ accuracy = nfoldCV_tree(labels, features, 0.9, 3)
 Random Forest Classifier
 ```julia
 # train random forest classifier
-# using 2 random features, 10 trees, and 0.5 portion of samples per tree (optional)
-model = build_forest(labels, features, 2, 10, 0.5)
+# using 2 random features, 10 trees, 0.5 portion of samples per tree (optional), and a maximum tree depth of 6 (optional)
+model = build_forest(labels, features, 2, 10, 0.5, 6)
 # apply learned model
 apply_forest(model, [5.9,3.0,5.1,1.9])
 # get the probability of each label
@@ -125,7 +125,7 @@ pipelines, ...) The classifier example above can be rewritten as:
 
 ```julia
 # train full-tree classifier
-model = DecisionTreeClassifier(pruning_purity_threshold=0.9)
+model = DecisionTreeClassifier(pruning_purity_threshold=0.9, maxdepth=6)
 fit!(model, features, labels)
 # pretty print of the tree, to a depth of 5 nodes (optional)
 print_tree(model.root, 5)

--- a/src/scikitlearnAPI.jl
+++ b/src/scikitlearnAPI.jl
@@ -240,4 +240,6 @@ predict_proba(ada::AdaBoostStumpClassifier, X) =
 ################################################################################
 # Common functions
 
-depth(dt::Union{DecisionTreeClassifier, DecisionTreeRegressor}) = depth(dt.root)
+# Cannot use Union{} in Julia 0.3
+depth(dt::DecisionTreeClassifier) = depth(dt.root)
+depth(dt::DecisionTreeRegressor) = depth(dt.root)

--- a/test/classification_scikitlearn.jl
+++ b/test/classification_scikitlearn.jl
@@ -18,3 +18,12 @@ model = fit!(RandomForestClassifier(), features, labels)
 model = fit!(AdaBoostStumpClassifier(), features, labels)
 # Adaboost isn't so hot on this task, disabled for now
 mean(predict(model, features) .== labels)
+
+srand(2)
+N = 3000
+X = randn(N, 10)
+# TODO: we should probably support fit!(::DecisionTreeClassifier, ::BitArray)
+y = convert(Vector{Bool}, randn(N) .< 0)
+maxdepth = 5
+model = fit!(DecisionTreeClassifier(maxdepth=maxdepth), X, y)
+@test depth(model) == maxdepth - 1 # -1 because `depth` doesn't count leaves

--- a/test/regression_scikitlearn.jl
+++ b/test/regression_scikitlearn.jl
@@ -12,3 +12,11 @@ model = fit!(DecisionTreeRegressor(maxlabels=5, pruning_purity_threshold=0.1), f
 
 model = fit!(RandomForestRegressor(ntrees=10, maxlabels=5, nsubfeatures=2), features, labels)
 @test R2(labels, predict(model, features)) > 0.8
+
+srand(2)
+N = 3000
+X = randn(N, 10)
+y = randn(N)
+maxdepth = 5
+model = fit!(DecisionTreeRegressor(maxdepth=maxdepth), X, y)
+@test depth(model) == maxdepth - 1 # -1 because `depth` doesn't count leaves


### PR DESCRIPTION
I started off from @trouve-antoine's PR and went from there.

One minor note: `maxdepth=8` yields `depth(::Tree)=7`. Wikipedia agrees with you that leaves have depth=0:

> The depth of a node is the length of the path to its root (i.e., its root path)

so I should probably correct the `maxdepth` arguments to reflect that.