### PR TITLE
Speed up _split_info_gain

### DIFF
--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -56,8 +56,8 @@ immutable Ensemble{S, T}
     trees::Vector{Node{S, T}}
 end
 
-immutable UniqueRanges
-    v::AbstractVector
+immutable UniqueRanges{V<:AbstractVector}
+    v::V
 end
 
 start(u::UniqueRanges) = 1

--- a/src/classification.jl
+++ b/src/classification.jl
@@ -41,21 +41,7 @@ function _split(labels::Vector, features::Matrix, nsubfeatures::Int, weights::Ve
     end
 end
 
-function _split_info_gain(labels::Vector, features::Matrix, nsubfeatures::Int,
-                          rng::AbstractRNG)
-    nf = size(features, 2)
-    N = length(labels)
-
-    best = NO_BEST
-    best_val = -Inf
-
-    if nsubfeatures > 0
-        r = randperm(rng, nf)
-        inds = r[1:nsubfeatures]
-    else
-        inds = 1:nf
-    end
-
+function _split_info_gain_loop(best, best_val, inds, features, labels, N)
     for i in inds
         ord = sortperm(features[:,i])
         features_i = features[ord,i]
@@ -81,6 +67,24 @@ function _split_info_gain(labels::Vector, features::Matrix, nsubfeatures::Int,
         end
     end
     return best
+end
+
+function _split_info_gain(labels::Vector, features::Matrix, nsubfeatures::Int,
+                          rng::AbstractRNG)
+    nf = size(features, 2)
+    N = length(labels)
+
+    best = NO_BEST
+    best_val = -Inf
+
+    if nsubfeatures > 0
+        r = randperm(rng, nf)
+        inds = r[1:nsubfeatures]
+    else
+        inds = 1:nf
+    end
+
+    return _split_info_gain_loop(best, best_val, inds, features, labels, N)
 end
 
 function _split_neg_z1_loss(labels::Vector, features::Matrix, weights::Vector)


### PR DESCRIPTION
There are ~~two~~ one major change~~s~~. First thing is to wrap most of the body in a function to avoid type instability in a relatively hot loop caused by `inds`. ~~The other improvement is to use merge sort in `sortperm` which happens to be much faster for feature vectors.~~