### PR TITLE
reverting to old Node

### DIFF
--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -38,23 +38,27 @@ neg(arr) = map(!, arr)
 
 const NO_BEST=(0,0)
 
-immutable Leaf{S}
-    majority::S
-    values::Vector{S}
+immutable Leaf
+    majority::Any
+    values::Vector
 end
 
-immutable Node{S,T}
-    featid::Int
-    featval::T
-    left::Union{Leaf{S},Node{S, T}}
-    right::Union{Leaf{S},Node{S, T}}
+immutable Node
+    featid::Integer
+    featval::Any
+    left::Union{Leaf,Node}
+    right::Union{Leaf,Node}
 end
 
-@compat const LeafOrNode{S,T} = Union{Leaf{S},Node{S, T}}
+@compat const LeafOrNode = Union{Leaf,Node}
 
-immutable Ensemble{S, T}
-    trees::Vector{Node{S, T}}
+immutable Ensemble
+    trees::Vector{Node}
 end
+
+convert(::Type{Node}, x::Leaf) = Node(0, nothing, x, Leaf(nothing,[nothing]))
+promote_rule(::Type{Node}, ::Type{Leaf}) = Node
+promote_rule(::Type{Leaf}, ::Type{Node}) = Node
 
 immutable UniqueRanges{V<:AbstractVector}
     v::V


### PR DESCRIPTION
Reverting commit [1c8c3f7c08bbb5ed1cdd9ce9ea1c1fe9bb7b1fb6](https://github.com/bensadeghi/DecisionTree.jl/commit/1c8c3f7c08bbb5ed1cdd9ce9ea1c1fe9bb7b1fb6)
"make apply-* methods faster, by making summarize_votes type stable " 

The new ```Node``` definition was breaking training with heterogeneously typed features, and also certain ```build_forest``` runs where Leafs need to be promoted to Nodes.
