### PR TITLE
minor fixes and changes

### DIFF
--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -51,6 +51,10 @@ convert(::Type{Node}, x::Leaf) = Node(0, nothing, x, Leaf(nothing,[nothing]))
 promote_rule(::Type{Node}, ::Type{Leaf}) = Node
 promote_rule(::Type{Leaf}, ::Type{Node}) = Node
 
+function mean(l)
+  return sum(l) / length(l)
+end
+
 ##############################
 ########## Includes ##########
 

--- a/src/classification/main.jl
+++ b/src/classification/main.jl
@@ -71,7 +71,7 @@ end
 function build_tree(labels::Vector, features::Matrix, n_subfeatures=0, max_depth=-1,
                     min_samples_leaf=1, min_samples_split=2, min_purity_increase=0.0;
                     rng=Random.GLOBAL_RNG)
-    
+
     if max_depth == -1
         max_depth = typemax(Int64)
     end

--- a/src/classification/main.jl
+++ b/src/classification/main.jl
@@ -54,17 +54,18 @@ function build_stump(labels::Vector, features::Matrix, weights=[0];
         min_samples_split   = 2,
         min_purity_increase = 0.0,
         rng                 = rng)
-    test = []
-    function _convert(node::treeclassifier.NodeMeta, labels::Array)
+
+    function _convert(node::treeclassifier.NodeMeta, labels_list::Array, labels::Array)
         if node.is_leaf
-            return Leaf(labels[node.label], test)
+            return Leaf(labels_list[node.label], labels[node.region])
         else
-            left = _convert(node.l, labels)
-            right = _convert(node.r, labels)
+            left = _convert(node.l, labels_list, labels)
+            right = _convert(node.r, labels_list, labels)
             return Node(node.feature, node.threshold, left, right)
         end
     end
-    return _convert(t.root, t.list)
+
+    return _convert(t.root, t.list, labels[t.labels])
 end
 
 function build_tree(labels::Vector, features::Matrix, n_subfeatures=0, max_depth=-1,
@@ -91,17 +92,17 @@ function build_tree(labels::Vector, features::Matrix, n_subfeatures=0, max_depth
         min_purity_increase = Float64(min_purity_increase),
         rng                 = rng)
 
-    test = []
-    function _convert(node::treeclassifier.NodeMeta, labels::Array)
+    function _convert(node::treeclassifier.NodeMeta, labels_list::Array, labels::Array)
         if node.is_leaf
-            return Leaf(labels[node.label], test)
+            return Leaf(labels_list[node.label], labels[node.region])
         else
-            left = _convert(node.l, labels)
-            right = _convert(node.r, labels)
+            left = _convert(node.l, labels_list, labels)
+            right = _convert(node.r, labels_list, labels)
             return Node(node.feature, node.threshold, left, right)
         end
     end
-    return _convert(t.root, t.list)
+
+    return _convert(t.root, t.list, labels[t.labels])
 end
 
 function prune_tree(tree::LeafOrNode, purity_thresh=1.0)

--- a/src/classification/main.jl
+++ b/src/classification/main.jl
@@ -38,41 +38,8 @@ end
 
 ################################################################################
 
-function _split_neg_z1_loss(labels::Vector, features::Matrix, weights::Vector)
-    best = NO_BEST
-    best_val = -Inf
-    for i in 1:size(features,2)
-        domain_i = sort(unique(features[:,i]))
-        for thresh in domain_i[2:end]
-            cur_split = features[:,i] .< thresh
-            value = _neg_z1_loss(labels[cur_split], weights[cur_split]) + _neg_z1_loss(labels[(!).(cur_split)], weights[(!).(cur_split)])
-            if value > best_val
-                best_val = value
-                best = (i, thresh)
-            end
-        end
-    end
-    return best
-end
-
 function build_stump(labels::Vector, features::Matrix, weights=[0];
                      rng=Random.GLOBAL_RNG)
-    #=
-    if weights == [0]
-        return build_tree(labels, features, 0, 1)
-    end
-    S = _split_neg_z1_loss(labels, features, weights)
-    if S == NO_BEST
-        return Leaf(majority_vote(labels), labels)
-    end
-    id, thresh = S
-    left = features[:,id] .< thresh
-    l_labels = labels[left]
-    r_labels = labels[(!).(left)]
-    return Node(id, thresh,
-                Leaf(majority_vote(l_labels), l_labels),
-                Leaf(majority_vote(r_labels), r_labels))
-    =#
     if weights == [0]
         weights = nothing
     end

--- a/src/classification/tree.jl
+++ b/src/classification/tree.jl
@@ -4,83 +4,92 @@
 
 # written by Poom Chiarawongse <eight1911@gmail.com>
 
+# TODO: Test weights support
+# TODO: Add min_weights_leaf prepruning
+# Add options for different purity criterion
+
 module treeclassifier
     include("../util.jl")
     import Random
 
     export fit
 
-    mutable struct NodeMeta
-        l           :: NodeMeta  # right child
-        r           :: NodeMeta  # left child
-        labels      :: Array{Int64}
-        label       :: Int64  # most likely label
-        feature     :: Int64  # feature used for splitting
-        threshold   :: Any # threshold value
+    mutable struct NodeMeta{S}
+        l           :: NodeMeta{S} # right child
+        r           :: NodeMeta{S} # left child
+        # labels    :: Vector{Int64}
+        label       :: Int64 # most likely label
+        feature     :: Int64 # feature used for splitting
+        threshold   :: S     # threshold value
         is_leaf     :: Bool
 
         depth       :: Int64
         region      :: UnitRange{Int64} # a slice of the samples used to decide the split of the node
-        features    :: Array{Int64} # a list of features not known to be constant
+        features    :: Vector{Int64}    # a list of features not known to be constant
 
-        split_at    :: Int64            # index of samples
-        NodeMeta(features, region, depth) = (
-            node = new();
-            node.depth = depth;
-            node.region = region;
-            node.features = features;
-            node.is_leaf = false;
-            node)
+        split_at    :: Int64     # index of samples
+
+        function NodeMeta{S}(features, region, depth) where S
+            node = new{S}()
+            node.depth = depth
+            node.region = region
+            node.features = features
+            node.is_leaf = false
+            node
+        end
     end
 
-    mutable struct Tree{T}
-        root :: NodeMeta
-        list :: Array{T}
+    struct Tree{S, T}
+        root   :: NodeMeta{S}
+        list   :: Vector{T}
+        labels :: Vector{Int64}
     end
-
 
     # find an optimal split that satisfy the given constraints
     # (max_depth, min_samples_split, min_purity_increase)
-    function _split!(X                   :: Matrix{T}, # the feature array
-                     Y                   :: Array{Int64, 1}, # the label array
-                     node                :: NodeMeta, # the node to split
-                     n_classes           :: Int64, # the total number of different labels
-                     max_features        :: Int64, # number of features to consider
-                     max_depth           :: Int64, # the maximum depth of the resultant tree
-                     min_samples_leaf    :: Int64, # the minimum number of samples each leaf needs to have
-                     min_samples_split   :: Int64, # the minimum number of samples in needed for a split
-                     min_purity_increase :: Float64, # minimum purity needed for a split
-                     indX                :: Array{Int64, 1}, # an array of sample indices,
-                                                             # we split using samples in indX[node.region]
-                     # the five arrays below are given for optimization purposes
-                     nc                  :: Array{Int64}, # nc maintains a dictionary of all labels in the samples
-                     ncl                 :: Array{Int64}, # ncl maintains the counts of labels on the left
-                     ncr                 :: Array{Int64}, # ncr maintains the counts of labels on the right
-                     Xf                  :: Array{T},
-                     Yf                  :: Array{Int64},
-                     rng                 :: Random.AbstractRNG) where T <: Any
+    function _split!(
+            X                   :: Matrix{S}, # the feature array
+            Y                   :: Vector{Int64}, # the label array
+            W                   :: Vector{U}, # the weight vector
+            purity_function     :: Function,
+            node                :: NodeMeta{S}, # the node to split
+            max_features        :: Int64, # number of features to consider
+            max_depth           :: Int64, # the maximum depth of the resultant tree
+            min_samples_leaf    :: Int64, # the minimum number of samples each leaf needs to have
+            min_samples_split   :: Int64, # the minimum number of samples in needed for a split
+            min_purity_increase :: Float64, # minimum purity needed for a split
+            indX                :: Vector{Int64}, # an array of sample indices,
+                                               # we split using samples in indX[node.region]
+            # the six arrays below are given for optimization purposes
+            nc                  :: Vector{U}, # nc maintains a dictionary of all labels in the samples
+            ncl                 :: Vector{U}, # ncl maintains the counts of labels on the left
+            ncr                 :: Vector{U}, # ncr maintains the counts of labels on the right
+            Xf                  :: Vector{S},
+            Yf                  :: Vector{Int64},
+            Wf                  :: Vector{U},
+            rng                 :: Random.AbstractRNG) where {S, U}
         region = node.region
         n_samples = length(region)
-        r_start = region.start - 1
-        @simd for lab in 1:n_classes
-            @inbounds nc[lab] = 0
-        end
+        n_classes = length(nc)
 
+
+        nc[:] .= 0
         @simd for i in region
-            @inbounds nc[Y[indX[i]]] += 1
+            @inbounds nc[Y[indX[i]]] += W[indX[i]]
         end
 
+        nt = sum(nc)
         node.label = argmax(nc)
 
-        if (min_samples_leaf * 2  >  n_samples
-         || min_samples_split     >  n_samples
-         || max_depth             <= node.depth
-         || n_samples             == nc[node.label])
-            node.labels = nc[:]
+        if (min_samples_leaf * 2 >  n_samples
+         || min_samples_split    >  n_samples
+         || max_depth            <= node.depth
+         || nt - nc[node.label]  == 0)
+            #node.labels = nc[:]
             node.is_leaf = true
             return
         end
-
+        r_start = region.start - 1
         features = node.features
         n_features = length(features)
         best_purity = -Inf
@@ -90,7 +99,7 @@ module treeclassifier
 
         indf = 1
         # the number of new constants found during this split
-        n_constant = 0
+        n_const = 0
         # true if every feature is constant
         unsplittable = true
         # the number of non constant features we will see if
@@ -99,10 +108,10 @@ module treeclassifier
         total_features = size(X, 2)
         # this is the total number of features that we expect to not
         # be one of the known constant features. since we know exactly
-        # what the non constant features are, we can sample at 'non_constants_used'
+        # what the non constant features are, we can sample at 'non_consts_used'
         # non constant features instead of going through every feature randomly.
-        non_constants_used = util.hypergeometric(n_features, total_features-n_features, max_features, rng)
-        @inbounds while (unsplittable || indf <= non_constants_used) && indf <= n_features
+        non_consts_used = util.hypergeometric(n_features, total_features-n_features, max_features, rng)
+        @inbounds while (unsplittable || indf <= non_consts_used) && indf <= n_features
             feature = let
                 indr = rand(rng, indf:n_features)
                 features[indf], features[indr] = features[indr], features[indf]
@@ -111,21 +120,23 @@ module treeclassifier
 
             # in the begining, every node is
             # on right of the threshold
-            @simd for lab in 1:n_classes
-                ncl[lab] = 0
-                ncr[lab] = nc[lab]
-            end
+            ncl[:] .= 0
+            ncr[:] = nc
 
             @simd for i in 1:n_samples
-                sub_i = indX[i + r_start]
-                Yf[i] = Y[sub_i]
-                Xf[i] = X[sub_i, feature]
+                Xf[i] = X[indX[i + r_start], feature]
             end
 
-            # sort Yf and Xf by Xf
-            util.q_bi_sort!(Xf, Yf, 1, n_samples)
-            nl, nr = 0, n_samples
-            lo, hi = 0, 0
+            # sort Yf and indX by Xf
+            util.q_bi_sort!(Xf, indX, 1, n_samples, r_start)
+
+            @simd for i in 1:n_samples
+                Yf[i] = Y[indX[i + r_start]]
+                Wf[i] = W[indX[i + r_start]]
+            end
+
+            hi = 0
+            nl, nr = 0, nt
             is_constant = true
             last_f = Xf[1]
             while hi < n_samples
@@ -135,12 +146,15 @@ module treeclassifier
                     ? searchsortedlast(Xf, curr_f, lo, n_samples, Base.Order.Forward)
                     : lo)
 
-                (nl != 0) && (is_constant = false)
+                (lo != 1) && (is_constant = false)
                 # honor min_samples_leaf
-                if nl >= min_samples_leaf && nr >= min_samples_leaf
+                # if nl >= min_samples_leaf && nr >= min_samples_leaf
+                # @assert nl == lo-1,
+                # @assert nr == n_samples - (lo-1) == n_samples - lo + 1
+                if lo-1 >= min_samples_leaf && n_samples - (lo-1) >= min_samples_leaf
                     unsplittable = false
-                    purity = -(nl * util.entropy(ncl, nl)
-                             + nr * util.entropy(ncr, nr))
+                    purity = -(nl * purity_function(ncl, nl)
+                             + nr * purity_function(ncr, nr))
                     if purity > best_purity
                         # will take average at the end
                         threshold_lo = last_f
@@ -150,38 +164,32 @@ module treeclassifier
                     end
                 end
 
-                let delta = hi - lo + 1
-                    nl += delta
-                    nr -= delta
-                end
                 # fill ncl and ncr in the direction
                 # that would require the smaller number of iterations
                 if (hi << 1) < n_samples + lo # i.e., hi - lo < n_samples - hi
                     @simd for i in lo:hi
-                        ncr[Yf[i]] -= 1
-                    end
-                    @simd for lab in 1:n_classes
-                        ncl[lab] = nc[lab] - ncr[lab]
+                        ncr[Yf[i]] -= Wf[i]
                     end
                 else
-                    @simd for lab in 1:n_classes
-                        ncr[lab] = 0
-                    end
+                    ncr[:] .= 0
                     @simd for i in (hi+1):n_samples
-                        ncr[Yf[i]] += 1
-                    end
-                    @simd for lab in 1:n_classes
-                        ncl[lab] = nc[lab] - ncr[lab]
+                        ncr[Yf[i]] += Wf[i]
                     end
                 end
+                nr = 0
+                @simd for lab in 1:n_classes
+                    nr += ncr[lab]
+                    ncl[lab] = nc[lab] - ncr[lab]
+                end
+                nl = nt - nr
 
                 last_f = curr_f
             end
 
             # keep track of constant features to be used later.
             if is_constant
-                n_constant += 1
-                features[indf], features[n_constant] = features[n_constant], features[indf]
+                n_const += 1
+                features[indf], features[n_const] = features[n_const], features[indf]
             end
 
             indf += 1
@@ -189,8 +197,8 @@ module treeclassifier
 
         # no splits honor min_samples_leaf
         @inbounds if (unsplittable
-            || (best_purity / n_samples + util.entropy(nc, n_samples) < min_purity_increase))
-            node.labels = nc[:]
+            || (best_purity / nt + util.entropy(nc, nt) < min_purity_increase))
+            # node.labels = nc[:]
             node.is_leaf = true
             return
         else
@@ -210,43 +218,43 @@ module treeclassifier
             # (so we partition at threshold_lo instead of node.threshold)
             node.split_at = util.partition!(indX, Xf, threshold_lo, region)
             node.feature = best_feature
-            node.features = features[(n_constant+1):n_features]
+            node.features = features[(n_const+1):n_features]
         end
 
-    end
+        return _split!
 
-    @inline function fork!(node :: NodeMeta)
+    end
+    @inline function fork!(node::NodeMeta{S}) where S
         ind = node.split_at
         region = node.region
         features = node.features
         # no need to copy because we will copy at the end
-        node.l = NodeMeta(features, region[    1:ind], node.depth + 1)
-        node.r = NodeMeta(features, region[ind+1:end], node.depth + 1)
+        node.l = NodeMeta{S}(features, region[    1:ind], node.depth + 1)
+        node.r = NodeMeta{S}(features, region[ind+1:end], node.depth + 1)
     end
 
-
-    # To do: check that Y actually has
-    # meta.n_classes classes
-    function check_input(X                   :: Matrix,
-                         Y                   :: Array{Int64, 1},
+    function check_input(X                   :: Matrix{S},
+                         Y                   :: Vector{T},
+                         W                   :: Vector{U},
                          max_features        :: Int64,
                          max_depth           :: Int64,
                          min_samples_leaf    :: Int64,
                          min_samples_split   :: Int64,
-                         min_purity_increase :: Float64)
+                         min_purity_increase :: Float64) where {S, T, U}
         n_samples, n_features = size(X)
         if length(Y) != n_samples
             throw("dimension mismatch between X and Y ($(size(X)) vs $(size(Y))")
-
+        elseif length(W) != n_samples
+            throw("dimension mismatch between X and W ($(size(X)) vs $(size(Y))")
+        elseif max_depth < -1
+            throw("unexpected value for max_depth: $(max_depth) (expected:"
+                * " max_depth >= 0, or max_depth = -1 for infinite depth)")
         elseif n_features < max_features
-            throw("number of features $(n_features) "
-                * "is less than the number of "
-                * "max features $(max_features)")
-
+            throw("number of features $(n_features) is less than the number "
+                * "of max features $(max_features)")
         elseif min_samples_leaf < 1
             throw("min_samples_leaf must be a positive integer "
                 * "(given $(min_samples_leaf))")
-
         elseif min_samples_split < 2
             throw("min_samples_split must be at least 2 "
                 * "(given $(min_samples_split))")
@@ -269,7 +277,7 @@ module treeclassifier
     #   2 => '1760s',
     # }
     #
-    function assign(Y :: Array{T}) where T<:Any
+    function assign(Y :: Vector{T}) where T
         label_set = Set{T}()
         for y in Y
             push!(label_set, y)
@@ -288,50 +296,50 @@ module treeclassifier
         return label_list, _Y
     end
 
-    function fit(X                   :: Matrix{T},
-                 Y                   :: Vector,
-                 max_features        :: Int64,
-                 max_depth           :: Int64,
-                 min_samples_leaf    :: Int64,
-                 min_samples_split   :: Int64,
-                 min_purity_increase :: Float64;
-                 rng=Random.GLOBAL_RNG :: Random.AbstractRNG) where T <: Any
-        n_samples, n_features = size(X)
-        label_list, _Y = assign(Y)
-        n_classes = Int64(length(label_list))
-        check_input(
-            X, _Y,
-            max_features,
-            max_depth,
-            min_samples_leaf,
-            min_samples_split,
-            min_purity_increase)
-        indX = collect(Int64(1):Int64(n_samples))
-        tree = let
-            @inbounds root = NodeMeta(collect(1:n_features), 1:n_samples, 0)
-            Tree(root, label_list)
-        end
-        stack = NodeMeta[ tree.root ]
+    function _fit(;
+            X                     :: Matrix{S},
+            Y                     :: Vector{Int64},
+            W                     :: Vector{U},
+            loss                  :: Function,
+            n_classes             :: Int64,
+            max_features          :: Int64,
+            max_depth             :: Int64,
+            min_samples_leaf      :: Int64,
+            min_samples_split     :: Int64,
+            min_purity_increase   :: Float64,
+            rng=Random.GLOBAL_RNG :: Random.AbstractRNG) where {S, U}
 
-        nc  = Array{Int64}(undef, n_classes)
-        ncl = Array{Int64}(undef, n_classes)
-        ncr = Array{Int64}(undef, n_classes)
-        Xf  = Array{T}(undef, n_samples)
+        n_samples, n_features = size(X)
+        nc  = Array{U}(undef, n_classes)
+        ncl = Array{U}(undef, n_classes)
+        ncr = Array{U}(undef, n_classes)
+        Wf  = Array{U}(undef, n_samples)
+        Xf  = Array{S}(undef, n_samples)
         Yf  = Array{Int64}(undef, n_samples)
+
+        indX = collect(1:n_samples)
+        root = NodeMeta{S}(collect(1:n_features), 1:n_samples, 0)
+        stack = NodeMeta{S}[root]
         @inbounds while length(stack) > 0
             node = pop!(stack)
             _split!(
                 X,
-                _Y,
+                Y,
+                W,
+                loss,
                 node,
-                n_classes,
                 max_features,
                 max_depth,
                 min_samples_leaf,
                 min_samples_split,
                 min_purity_increase,
                 indX,
-                nc, ncl, ncr, Xf, Yf,
+                nc, 
+                ncl,
+                ncr,
+                Xf,
+                Yf,
+                Wf,
                 rng)
             if !node.is_leaf
                 fork!(node)
@@ -339,6 +347,47 @@ module treeclassifier
                 push!(stack, node.l)
             end
         end
-        return tree
+
+        return (root, indX)
+    end
+
+    function fit(;
+            X                     :: Matrix{S},
+            Y                     :: Vector{T},
+            W                     :: Union{Nothing, Vector{U}},
+            max_features          :: Int64,
+            max_depth             :: Int64,
+            min_samples_leaf      :: Int64,
+            min_samples_split     :: Int64,
+            min_purity_increase   :: Float64,
+            rng=Random.GLOBAL_RNG :: Random.AbstractRNG) where {S, T, U}
+        n_samples, n_features = size(X)
+        label_list, Y_ = assign(Y)
+        if W == nothing
+            W = fill(1.0, n_samples)
+        end
+
+        check_input(
+            X, Y, W,
+            max_features,
+            max_depth,
+            min_samples_leaf,
+            min_samples_split,
+            min_purity_increase)
+
+        root, indX = _fit(
+            X                   = X,
+            Y                   = Y_,
+            W                   = W,
+            loss                = util.entropy,
+            n_classes           = length(label_list),
+            max_features        = max_features,
+            max_depth           = max_depth,
+            min_samples_leaf    = min_samples_leaf,
+            min_samples_split   = min_samples_split,
+            min_purity_increase = min_purity_increase,
+            rng                 = rng)
+        return Tree{S, T}(root, label_list, indX)
+
     end
 end

--- a/src/classification/tree.jl
+++ b/src/classification/tree.jl
@@ -6,13 +6,13 @@
 
 # TODO: Test weights support
 # TODO: Add min_weights_leaf prepruning
-# Add options for different purity criterion
+# TODO: add options for different purity criterions
 
 module treeclassifier
     include("../util.jl")
     import Random
 
-    export fit
+    export fit, fit_zero_one
 
     mutable struct NodeMeta{S}
         l           :: NodeMeta{S} # right child
@@ -380,6 +380,46 @@ module treeclassifier
             Y                   = Y_,
             W                   = W,
             loss                = util.entropy,
+            n_classes           = length(label_list),
+            max_features        = max_features,
+            max_depth           = max_depth,
+            min_samples_leaf    = min_samples_leaf,
+            min_samples_split   = min_samples_split,
+            min_purity_increase = min_purity_increase,
+            rng                 = rng)
+        return Tree{S, T}(root, label_list, indX)
+
+    end
+
+    function fit_zero_one(;
+            X                     :: Matrix{S},
+            Y                     :: Vector{T},
+            W                     :: Union{Nothing, Vector{U}},
+            max_features          :: Int64,
+            max_depth             :: Int64,
+            min_samples_leaf      :: Int64,
+            min_samples_split     :: Int64,
+            min_purity_increase   :: Float64,
+            rng=Random.GLOBAL_RNG :: Random.AbstractRNG) where {S, T, U}
+        n_samples, n_features = size(X)
+        label_list, Y_ = assign(Y)
+        if W == nothing
+            W = fill(1.0, n_samples)
+        end
+
+        check_input(
+            X, Y, W,
+            max_features,
+            max_depth,
+            min_samples_leaf,
+            min_samples_split,
+            min_purity_increase)
+
+        root, indX = _fit(
+            X                   = X,
+            Y                   = Y_,
+            W                   = W,
+            loss                = util.zero_one,
             n_classes           = length(label_list),
             max_features        = max_features,
             max_depth           = max_depth,

--- a/src/classification/tree.jl
+++ b/src/classification/tree.jl
@@ -73,7 +73,7 @@ module treeclassifier
         n_classes = length(nc)
 
 
-        nc[:] .= 0
+        nc[:] .= zero(U)
         @simd for i in region
             @inbounds nc[Y[indX[i]]] += W[indX[i]]
         end
@@ -119,7 +119,7 @@ module treeclassifier
 
             # in the begining, every node is
             # on right of the threshold
-            ncl[:] .= 0
+            ncl[:] .= zero(U)
             ncr[:] = nc
 
             @simd for i in 1:n_samples
@@ -135,7 +135,7 @@ module treeclassifier
             end
 
             hi = 0
-            nl, nr = 0, nt
+            nl, nr = zero(U), nt
             is_constant = true
             last_f = Xf[1]
             while hi < n_samples
@@ -170,12 +170,12 @@ module treeclassifier
                         ncr[Yf[i]] -= Wf[i]
                     end
                 else
-                    ncr[:] .= 0
+                    ncr[:] .= zero(U)
                     @simd for i in (hi+1):n_samples
                         ncr[Yf[i]] += Wf[i]
                     end
                 end
-                nr = 0
+                nr = zero(U)
                 @simd for lab in 1:n_classes
                     nr += ncr[lab]
                     ncl[lab] = nc[lab] - ncr[lab]
@@ -391,7 +391,7 @@ module treeclassifier
             min_samples_leaf      :: Int64,
             min_samples_split     :: Int64,
             min_purity_increase   :: Float64,
-            rng=Random.GLOBAL_RNG :: Random.AbstractRNG) where {S, T, U}
+            rng=Random.GLOBAL_RNG :: Random.AbstractRNG)::Tree{S, T} where {S, T, U}
         n_samples, n_features = size(X)
         label_list, Y_ = assign(Y)
         if W == nothing

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -27,7 +27,7 @@ function _hist_add!(counts::Dict{T, Int}, labels::Vector{T}, region::UnitRange{I
     return counts
 end
 
-_hist(labels::Vector{T}, region::UnitRange{Int} = 1:lastindex(labels)) where T = 
+_hist(labels::Vector{T}, region::UnitRange{Int} = 1:lastindex(labels)) where T =
     _hist_add!(Dict{T,Int}(), labels, region)
 
 function _neg_z1_loss(labels::Vector, weights::Vector{T}) where T <: Real
@@ -217,7 +217,7 @@ end
 nfoldCV_tree(labels::Vector{T}, features::Matrix, nfolds::Integer, maxlabels::Integer = 5) where T <: Float64 =
     _nfoldCV(:tree, labels, features, maxlabels, nfolds)
 
-nfoldCV_forest(labels::Vector{T}, features::Matrix, n_subfeatures::Integer, n_trees::Integer, nfolds::Integer, maxlabels::Integer = 5, partial_sampling = 0.7) where T <: Float64 = 
+nfoldCV_forest(labels::Vector{T}, features::Matrix, n_subfeatures::Integer, n_trees::Integer, nfolds::Integer, maxlabels::Integer = 5, partial_sampling = 0.7) where T <: Float64 =
     _nfoldCV(:forest, labels, features, n_subfeatures, n_trees, maxlabels, partial_sampling, nfolds)
 
 

--- a/src/regression/main.jl
+++ b/src/regression/main.jl
@@ -24,24 +24,28 @@ function build_tree(
     if n_subfeatures == 0
         n_subfeatures = size(features, 2)
     end
-    min_samples_leaf = Int64(min_samples_leaf)
-    min_samples_split = Int64(min_samples_split)
-    min_purity_increase = Float64(min_purity_increase)
-    t = treeregressor.fit(
-        features, labels, n_subfeatures, max_depth,
-        min_samples_leaf, min_samples_split, min_purity_increase, 
-        rng=rng)
 
+    t = treeregressor.fit(
+        X                   = features,
+        Y                   = labels,
+        W                   = nothing,
+        max_features        = n_subfeatures,
+        max_depth           = max_depth,
+        min_samples_leaf    = Int64(min_samples_leaf),
+        min_samples_split   = Int64(min_samples_split),
+        min_purity_increase = Float64(min_purity_increase),
+        rng                 = rng)
+    test = []
     function _convert(node :: treeregressor.NodeMeta)
         if node.is_leaf
-            return Leaf(node.label, node.labels)
+            return Leaf(node.label, test)
         else
             left = _convert(node.l)
             right = _convert(node.r)
             return Node(node.feature, node.threshold, left, right)
         end
     end
-    return _convert(t)
+    return _convert(t.root)
 end
 
 function build_forest(

--- a/src/regression/main.jl
+++ b/src/regression/main.jl
@@ -35,17 +35,17 @@ function build_tree(
         min_samples_split   = Int64(min_samples_split),
         min_purity_increase = Float64(min_purity_increase),
         rng                 = rng)
-    test = []
-    function _convert(node :: treeregressor.NodeMeta)
+    
+    function _convert(node::treeregressor.NodeMeta, labels::Array)
         if node.is_leaf
-            return Leaf(node.label, test)
+            return Leaf(node.label, labels[node.region])
         else
-            left = _convert(node.l)
-            right = _convert(node.r)
+            left = _convert(node.l, labels)
+            right = _convert(node.r, labels)
             return Node(node.feature, node.threshold, left, right)
         end
     end
-    return _convert(t.root)
+    return _convert(t.root, labels[t.labels])
 end
 
 function build_forest(

--- a/src/regression/main.jl
+++ b/src/regression/main.jl
@@ -35,7 +35,7 @@ function build_tree(
         min_samples_split   = Int64(min_samples_split),
         min_purity_increase = Float64(min_purity_increase),
         rng                 = rng)
-    
+
     function _convert(node::treeregressor.NodeMeta, labels::Array)
         if node.is_leaf
             return Leaf(node.label, labels[node.region])

--- a/src/regression/tree.jl
+++ b/src/regression/tree.jl
@@ -17,7 +17,6 @@ module treeregressor
     mutable struct NodeMeta{S}
         l           :: NodeMeta{S} # right child
         r           :: NodeMeta{S} # left child
-        # labels    :: Array{Float64}
         label       :: Float64  # most likely label
         feature     :: Int64    # feature used for splitting
         threshold   :: Any      # threshold value
@@ -85,7 +84,7 @@ module treeregressor
         if (min_samples_leaf * 2 >  n_samples
          || min_samples_split    >  n_samples
          || max_depth            <= node.depth
-         # equivalent to old_purity > -1e-7
+          # equivalent to old_purity > -1e-7
          || tsum * node.label    > -1e-7 * wsum + tssq)
             # node.labels = Yf[1:n_samples] # TODO : Add Wf[1:n_samples] to this thing
             node.is_leaf = true
@@ -263,7 +262,7 @@ module treeregressor
         end
     end
 
-    function _fit(;
+    function _fit(
             X                     :: Matrix{S},
             Y                     :: Vector{Float64},
             W                     :: Vector{U},
@@ -323,7 +322,9 @@ module treeregressor
         end
 
         check_input(
-            X, Y, W,
+            X,
+            Y,
+            W,
             max_features,
             max_depth,
             min_samples_leaf,
@@ -331,15 +332,15 @@ module treeregressor
             min_purity_increase)
 
         root, indX = _fit(
-            X                   = X,
-            Y                   = Y,
-            W                   = W,
-            max_features        = max_features,
-            max_depth           = max_depth,
-            min_samples_leaf    = min_samples_leaf,
-            min_samples_split   = min_samples_split,
-            min_purity_increase = min_purity_increase,
-            rng                 = rng)
+            X,
+            Y,
+            W,
+            max_features,
+            max_depth,
+            min_samples_leaf,
+            min_samples_split,
+            min_purity_increase,
+            rng)
 
         return Tree{S}(root, indX)
 

--- a/src/regression/tree.jl
+++ b/src/regression/tree.jl
@@ -74,7 +74,7 @@ module treeregressor
         tssq = 0.0
         tsum = 0.0
         wsum = 0.0
-        @simd for i in 1:n_samples
+        @inbounds @simd for i in 1:n_samples
             tssq += Wf[i]*Yf[i]*Yf[i]
             tsum += Wf[i]*Yf[i]
             wsum += Wf[i]

--- a/src/regression/tree.jl
+++ b/src/regression/tree.jl
@@ -4,16 +4,19 @@
 
 # written by Poom Chiarawongse <eight1911@gmail.com>
 
+# TODO: Test weights support
+# TODO: Add min_weights_leaf prepruning
+
 module treeregressor
     include("../util.jl")
 
     import Random
     export fit
 
-    mutable struct NodeMeta
-        l           :: NodeMeta  # right child
-        r           :: NodeMeta  # left child
-        labels      :: Array{Float64}
+    mutable struct NodeMeta{S}
+        l           :: NodeMeta{S} # right child
+        r           :: NodeMeta{S} # left child
+        # labels    :: Array{Float64}
         label       :: Float64  # most likely label
         feature     :: Int64    # feature used for splitting
         threshold   :: Any      # threshold value
@@ -24,55 +27,66 @@ module treeregressor
         features    :: Array{Int64} # a list of features not known to be constant
 
         split_at    :: Int64 # index of samples
-        NodeMeta(features, region, depth) = (
-            node = new();
-            node.depth = depth;
-            node.region = region;
-            node.features = features;
-            node.is_leaf = false;
-            node)
+        function NodeMeta{S}(features, region, depth) where S
+            node = new{S}()
+            node.depth = depth
+            node.region = region
+            node.features = features
+            node.is_leaf = false
+            node
+        end
+    end
+
+    struct Tree{S}
+        root   :: NodeMeta{S}
+        labels :: Vector{Int64}
     end
 
     # find an optimal split that satisfy the given constraints
     # (max_depth, min_samples_split, min_purity_increase)
-    function _split!(X                   :: Matrix{T}, # the feature array
-                     Y                   :: Array{Float64, 1}, # the label array
-                     node                :: NodeMeta, # the node to split
-                     max_features        :: Int64, # number of features to consider
-                     max_depth           :: Int64, # the maximum depth of the resultant tree
-                     min_samples_leaf    :: Int64, # the minimum number of samples each leaf needs to have
-                     min_samples_split   :: Int64, # the minimum number of samples in needed for a split
-                     min_purity_increase :: Float64, # minimum purity needed for a split
-                     indX                :: Array{Int64, 1}, # an array of sample indices,
-                                                             # we split using samples in indX[node.region]
-                     # the two arrays below are given for optimization purposes
-                     Xf                  :: Array{T},
-                     Yf                  :: Array{Float64},
-                     rng                 :: Random.AbstractRNG) where T <: Any
+    function _split!(
+            X                   :: Matrix{S}, # the feature array
+            Y                   :: Vector{Float64}, # the label array
+            W                   :: Vector{U},
+            node                :: NodeMeta{S}, # the node to split
+            max_features        :: Int64, # number of features to consider
+            max_depth           :: Int64, # the maximum depth of the resultant tree
+            min_samples_leaf    :: Int64, # the minimum number of samples each leaf needs to have
+            min_samples_split   :: Int64, # the minimum number of samples in needed for a split
+            min_purity_increase :: Float64, # minimum purity needed for a split
+            indX                :: Vector{Int64}, # an array of sample indices,
+                                               # we split using samples in indX[node.region]
+            # the two arrays below are given for optimization purposes
+            Xf                  :: Vector{S},
+            Yf                  :: Vector{Float64},
+            Wf                  :: Vector{U},
+            rng                 :: Random.AbstractRNG) where {S, U}
 
         region = node.region
         n_samples = length(region)
         r_start = region.start - 1
 
-        @simd for i in 1:n_samples
-            @inbounds Yf[i] = Y[indX[i + r_start]]
+        @inbounds @simd for i in 1:n_samples
+            Yf[i] = Y[indX[i + r_start]]
+            Wf[i] = W[indX[i + r_start]]
         end
 
         tssq = 0.0
         tsum = 0.0
+        wsum = 0.0
         @simd for i in 1:n_samples
-            val = Yf[i]
-            tssq += val*val
-            tsum += val
+            tssq += Wf[i]*Yf[i]*Yf[i]
+            tsum += Wf[i]*Yf[i]
+            wsum += Wf[i]
         end
 
-        node.label =  tsum / n_samples
+        node.label =  tsum / wsum
         if (min_samples_leaf * 2 >  n_samples
          || min_samples_split    >  n_samples
          || max_depth            <= node.depth
-         # equvalent to old_purity > -1e-7
-         || tsum * node.label    > -1e-7 * n_samples + tssq)
-            node.labels = Yf[1:n_samples]
+         # equivalent to old_purity > -1e-7
+         || tsum * node.label    > -1e-7 * wsum + tssq)
+            # node.labels = Yf[1:n_samples] # TODO : Add Wf[1:n_samples] to this thing
             node.is_leaf = true
             return
         end
@@ -83,15 +97,6 @@ module treeregressor
         best_feature = -1
         threshold_lo = Inf32
         threshold_hi = Inf32
-
-        # -- start --
-        # is this needed for initialization?
-        # i have no idea, but we'll see
-        rssq = tssq
-        lssq = 0.0
-        rsum = tsum
-        lsum = 0.0
-        # --  end  --
 
         indf = 1
         # the number of new constants found during this split
@@ -121,18 +126,20 @@ module treeregressor
             lsum = 0.0
 
             @simd for i in 1:n_samples
-                sub_i = indX[i + r_start]
-                Yf[i] = Y[sub_i]
-                Xf[i] = X[sub_i, feature]
+                Xf[i] = X[indX[i + r_start], feature]
             end
 
-            # sort Yf and Xf by Xf
-            util.q_bi_sort!(Xf, Yf, 1, n_samples)
-            nl, nr = 0, n_samples
+            # sort Yf and indX by Xf
+            util.q_bi_sort!(Xf, indX, 1, n_samples, r_start)
+            @simd for i in 1:n_samples
+                Yf[i] = Y[indX[i + r_start]]
+                Wf[i] = W[indX[i + r_start]]
+            end
+            nl, nr = 0.0, wsum
             # lo and hi are the indices of
             # the least upper bound and the greatest lower bound
             # of the left and right nodes respectively
-            lo, hi = 0, 0
+            hi = 0
             last_f = Xf[1]
             is_constant = true
             while hi < n_samples
@@ -142,45 +149,39 @@ module treeregressor
                     ? searchsortedlast(Xf, curr_f, lo, n_samples, Base.Order.Forward)
                     : lo)
 
-                (nl != 0) && (is_constant = false)
+                (lo != 1) && (is_constant = false)
                 # honor min_samples_leaf
-                if nl >= min_samples_leaf && nr >= min_samples_leaf
+                if lo-1 >= min_samples_leaf && n_samples - (lo-1) >= min_samples_leaf
                     unsplittable = false
                     purity = (rsum * rsum / nr) + (lsum * lsum / nl)
                     if purity > best_purity
                         # will take average at the end, if possible
                         threshold_lo = last_f
                         threshold_hi = curr_f
-                        best_purity = purity
+                        best_purity  = purity
                         best_feature = feature
                     end
-                end
-
-                let delta = hi - lo + 1
-                    nl += delta
-                    nr -= delta
                 end
 
                 # update, lssq, rssq, lsum, rsum in the direction
                 # that would require the smaller number of iterations
                 if (hi << 1) < n_samples + lo # i.e., hi - lo < n_samples - hi
                     @simd for i in lo:hi
-                        lab  = Yf[i]
-                        lsum += lab
-                        lssq += lab*lab
+                        nr   -= Wf[i]
+                        rsum -= Wf[i]*Yf[i]
+                        rssq -= Wf[i]*Yf[i]*Yf[i]
                     end
-                    rsum = tsum - lsum
-                    rssq = tssq - lssq
                 else
-                    rsum = rssq = 0.0
+                    nr = rsum = rssq = 0.0
                     @simd for i in (hi+1):n_samples
-                        lab  = Yf[i]
-                        rsum += lab
-                        rssq += lab*lab
+                        nr   += Wf[i]
+                        rsum += Wf[i]*Yf[i]
+                        rssq += Wf[i]*Yf[i]*Yf[i]
                     end
-                    lsum = tsum - rsum
-                    lssq = tssq - rssq
                 end
+                lsum = tsum - rsum
+                lssq = tssq - rssq
+                nl   = wsum - nr
 
                 last_f = curr_f
             end
@@ -195,21 +196,18 @@ module treeregressor
         end
 
         # no splits honor min_samples_leaf
-        @inbounds if unsplittable
-            node.labels = Yf[1:n_samples]
+        @inbounds if (unsplittable
+                || best_purity - tsum * node.label < min_purity_increase * wsum)
+            # node.labels = Yf[1:n_samples] #TODO Add Wf support
             node.is_leaf = true
             return
         else
             # new_purity - old_purity < stop.min_purity_increase
-            if (best_purity - tsum * node.label < min_purity_increase * n_samples)
-                node.labels = Yf[1:n_samples]
-                node.is_leaf = true
-                return
-            end
             bf = Int64(best_feature)
             @simd for i in 1:n_samples
-                Xf[i] = X[indX[i + r_start], bf]
+                Xf[i] = X[indX[i + r_start], best_feature]
             end
+
             try
                 node.threshold = (threshold_lo + threshold_hi) / 2.0
             catch
@@ -226,71 +224,69 @@ module treeregressor
 
     end
 
-    @inline function fork!(node :: NodeMeta)
+    @inline function fork!(node :: NodeMeta{S}) where S
         ind = node.split_at
         region = node.region
         features = node.features
         # no need to copy because we will copy at the end
-        node.l = NodeMeta(features, region[    1:ind], node.depth + 1)
-        node.r = NodeMeta(features, region[ind+1:end], node.depth + 1)
+        node.l = NodeMeta{S}(features, region[    1:ind], node.depth + 1)
+        node.r = NodeMeta{S}(features, region[ind+1:end], node.depth + 1)
     end
 
-
-    # To do: check that Y actually has
-    # meta.n_classes classes
-    function check_input(X                   :: Matrix,
-                         Y                   :: Array{Float64, 1},
-                         max_features        :: Int64,
-                         max_depth           :: Int64,
-                         min_samples_leaf    :: Int64,
-                         min_samples_split   :: Int64,
-                         min_purity_increase :: Float64)
+    function check_input(
+            X                   :: Matrix{S},
+            Y                   :: Vector{T},
+            W                   :: Vector{U},
+            max_features        :: Int64,
+            max_depth           :: Int64,
+            min_samples_leaf    :: Int64,
+            min_samples_split   :: Int64,
+            min_purity_increase :: Float64) where {S, T, U}
         n_samples, n_features = size(X)
         if length(Y) != n_samples
             throw("dimension mismatch between X and Y ($(size(X)) vs $(size(Y))")
-
+        elseif length(W) != n_samples
+            throw("dimension mismatch between X and W ($(size(X)) vs $(size(Y))")
+        elseif max_depth < -1
+            throw("unexpected value for max_depth: $(max_depth) (expected:"
+                * " max_depth >= 0, or max_depth = -1 for infinite depth)")
         elseif n_features < max_features
-            throw("number of features $(n_features) "
-                * "is less than the number of "
-                * "max features $(max_features)")
-
+            throw("number of features $(n_features) is less than the number "
+                * "of max features $(max_features)")
         elseif min_samples_leaf < 1
             throw("min_samples_leaf must be a positive integer "
                 * "(given $(min_samples_leaf))")
-
         elseif min_samples_split < 2
             throw("min_samples_split must be at least 2 "
                 * "(given $(min_samples_split))")
         end
     end
 
-    function fit(X                   :: Matrix{T},
-                 Y                   :: Vector,
-                 max_features        :: Int64,
-                 max_depth           :: Int64,
-                 min_samples_leaf    :: Int64,
-                 min_samples_split   :: Int64,
-                 min_purity_increase :: Float64;
-                 rng=Random.GLOBAL_RNG :: Random.AbstractRNG) where T <: Any
-        n_samples, n_features = size(X)
-        check_input(
-            X, Y,
-            max_features,
-            max_depth,
-            min_samples_leaf,
-            min_samples_split,
-            min_purity_increase)
-        indX = collect(Int64(1):Int64(n_samples))
-        root = NodeMeta(collect(1:n_features), 1:n_samples, 0)
-        stack = NodeMeta[ root ]
+    function _fit(;
+            X                     :: Matrix{S},
+            Y                     :: Vector{Float64},
+            W                     :: Vector{U},
+            max_features          :: Int64,
+            max_depth             :: Int64,
+            min_samples_leaf      :: Int64,
+            min_samples_split     :: Int64,
+            min_purity_increase   :: Float64,
+            rng=Random.GLOBAL_RNG :: Random.AbstractRNG) where {S, U}
 
-        Xf  = Array{T}(undef, n_samples)
+        n_samples, n_features = size(X)
+
+        Xf  = Array{S}(undef, n_samples)
         Yf  = Array{Float64}(undef, n_samples)
+        Wf  = Array{eltype(W)}(undef, n_samples)
+
+        indX = collect(Int64(1):Int64(n_samples))
+        root = NodeMeta{S}(collect(1:n_features), 1:n_samples, 0)
+        stack = NodeMeta{S}[root]
+
         @inbounds while length(stack) > 0
             node = pop!(stack)
             _split!(
-                X,
-                Y,
+                X, Y, W,
                 node,
                 max_features,
                 max_depth,
@@ -298,7 +294,7 @@ module treeregressor
                 min_samples_split,
                 min_purity_increase,
                 indX,
-                Xf, Yf,
+                Xf, Yf, Wf,
                 rng)
             if !node.is_leaf
                 fork!(node)
@@ -306,6 +302,45 @@ module treeregressor
                 push!(stack, node.l)
             end
         end
-        return root
+        return (root, indX)
+    end
+
+    function fit(;
+            X                     :: Matrix{S},
+            Y                     :: Vector{Float64},
+            W                     :: Union{Nothing, Vector{U}},
+            max_features          :: Int64,
+            max_depth             :: Int64,
+            min_samples_leaf      :: Int64,
+            min_samples_split     :: Int64,
+            min_purity_increase   :: Float64,
+            rng=Random.GLOBAL_RNG :: Random.AbstractRNG) where {S, U}
+
+        n_samples, n_features = size(X)
+        if W == nothing
+            W = fill(1.0, n_samples)
+        end
+
+        check_input(
+            X, Y, W,
+            max_features,
+            max_depth,
+            min_samples_leaf,
+            min_samples_split,
+            min_purity_increase)
+
+        root, indX = _fit(
+            X                   = X,
+            Y                   = Y,
+            W                   = W,
+            max_features        = max_features,
+            max_depth           = max_depth,
+            min_samples_leaf    = min_samples_leaf,
+            min_samples_split   = min_samples_split,
+            min_purity_increase = min_purity_increase,
+            rng                 = rng)
+
+        return Tree{S}(root, indX)
+
     end
 end

--- a/src/regression/tree.jl
+++ b/src/regression/tree.jl
@@ -6,6 +6,7 @@
 
 # TODO: Test weights support
 # TODO: Add min_weights_leaf prepruning
+# TODO: Add tests for build_stumps
 
 module treeregressor
     include("../util.jl")

--- a/src/scikitlearnAPI.jl
+++ b/src/scikitlearnAPI.jl
@@ -192,7 +192,7 @@ function fit!(rf::RandomForestClassifier, X::Matrix, y::Vector)
     rf
 end
 
-predict_proba(rf::RandomForestClassifier, X) = 
+predict_proba(rf::RandomForestClassifier, X) =
     apply_forest_proba(rf.ensemble, X, rf.classes)
 
 predict(rf::RandomForestClassifier, X) = apply_forest(rf.ensemble, X)

--- a/src/util.jl
+++ b/src/util.jl
@@ -3,12 +3,12 @@
 
 module util
 
-    export gini, entropy, loss01, q_bi_sort!, hypergeometric
+    export gini, entropy, zero_one, q_bi_sort!, hypergeometric
 
     # returns the gini purity of ns/n
 
-    @inline function loss01(ns, n)
-        return 1.0 - max(ns) / n
+    @inline function zero_one(ns, n)
+        return 1.0 - maximum(ns) / n
     end
 
     @inline function gini(ns, n)

--- a/src/util.jl
+++ b/src/util.jl
@@ -147,12 +147,12 @@ module util
 
 
     # The code function below is a small port from numpy's library
-    # library which is distributed under the 3-Clause BSD license. 
-    # The rest of DecisionTree.jl is released under the MIT license. 
+    # library which is distributed under the 3-Clause BSD license.
+    # The rest of DecisionTree.jl is released under the MIT license.
 
     # ported by Poom Chiarawongse <eight1911@gmail.com>
 
-    # this is the code for efficient generation 
+    # this is the code for efficient generation
     # of hypergeometric random variables ported from numpy.random
     function hypergeometric(good, bad, sample, rng)
 
@@ -174,7 +174,7 @@ module util
             gl0 = gl0 * x2 - 1.917526917526918e-03
             gl0 = gl0 * x2 + 8.417508417508418e-04
             gl0 = gl0 * x2 - 5.952380952380952e-04
-            gl0 = gl0 * x2 + 7.936507936507937e-04 
+            gl0 = gl0 * x2 + 7.936507936507937e-04
             gl0 = gl0 * x2 - 2.777777777777778e-03
             gl0 = gl0 * x2 + 8.333333333333333e-02
             gl = gl0/x0 + 0.5*log(xp) + (x0-0.5)*log(x0) - x0
@@ -206,7 +206,7 @@ module util
             else
                 Z
             end
-        end 
+        end
 
         @inline function hypergeometric_hrua(good, bad, sample)
             mingoodbad = min(good, bad)

--- a/src/util.jl
+++ b/src/util.jl
@@ -3,10 +3,15 @@
 
 module util
 
-    export gini, entropy, q_bi_sort!, hypergeometric
+    export gini, entropy, loss01, q_bi_sort!, hypergeometric
 
     # returns the gini purity of ns/n
-    @inline function gini(ns::Array{Int64}, n::Int64)
+
+    @inline function loss01(ns, n)
+        return 1.0 - max(ns) / n
+    end
+
+    @inline function gini(ns, n)
         s = 0.0
         @simd for k in ns
             s += k * (n - k)
@@ -15,7 +20,7 @@ module util
     end
 
     # returns the entropy of ns/n
-    @inline function entropy(ns::Array{Int64}, n::Int64)
+    @inline function entropy(ns, n)
         s = 0.0
         @simd for k in ns
             if k > 0
@@ -43,28 +48,27 @@ module util
     end
 
     # adapted from the Julia Base.Sort Library
-    function insert_sort!(v, w, lo, hi)
+    function insert_sort!(v, w, lo, hi, offset)
         @inbounds for i = lo+1:hi
             j = i
             x = v[i]
-            y = w[i]
+            y = w[offset+i]
             while j > lo
                 if x < v[j-1]
                     v[j] = v[j-1]
-                    w[j] = w[j-1]
+                    w[offset+j] = w[offset+j-1]
                     j -= 1
                     continue
                 end
                 break
             end
             v[j] = x
-            w[j] = y
+            w[offset+j] = y
         end
         return v
     end
 
-    # adapted from the Julia Base.Sort Library
-    @inline function _selectpivot!(v, w, lo, hi)
+    @inline function _selectpivot!(v, w, lo, hi, offset)
         @inbounds begin
             mi = (lo+hi)>>>1
 
@@ -72,32 +76,32 @@ module util
 
             if v[mi] < v[lo]
                 v[mi], v[lo] = v[lo], v[mi]
-                w[mi], w[lo] = w[lo], w[mi]
+                w[offset+mi], w[offset+lo] = w[offset+lo], w[offset+mi]
             end
             if v[hi] < v[mi]
                 if v[hi] < v[lo]
                     v[lo], v[mi], v[hi] = v[hi], v[lo], v[mi]
-                    w[lo], w[mi], w[hi] = w[hi], w[lo], w[mi]
+                    w[offset+lo], w[offset+mi], w[offset+hi] = w[offset+hi], w[offset+lo], w[offset+mi]
                 else
                     v[hi], v[mi] = v[mi], v[hi]
-                    w[hi], w[mi] = w[mi], w[hi]
+                    w[offset+hi], w[offset+mi] = w[offset+mi], w[offset+hi]
                 end
             end
 
             # move v[mi] to v[lo] and use it as the pivot
             v[lo], v[mi] = v[mi], v[lo]
-            w[lo], w[mi] = w[mi], w[lo]
-            pivot = v[lo]
-            w_piv = w[lo]
+            w[offset+lo], w[offset+mi] = w[offset+mi], w[offset+lo]
+            v_piv = v[lo]
+            w_piv = w[offset+lo]
         end
 
         # return the pivot
-        return pivot, w_piv
+        return v_piv, w_piv
     end
 
     # adapted from the Julia Base.Sort Library
-    @inline function _bi_partition!(v, w, lo, hi)
-        pivot, w_piv = _selectpivot!(v, w, lo, hi)
+    @inline function _bi_partition!(v, w, lo, hi, offset)
+        pivot, w_piv = _selectpivot!(v, w, lo, hi, offset)
         # pivot == v[lo], v[hi] > pivot
         i, j = lo, hi
         @inbounds while true
@@ -106,10 +110,10 @@ module util
             while pivot < v[j]; j -= 1; end;
             i >= j && break
             v[i], v[j] = v[j], v[i]
-            w[i], w[j] = w[j], w[i]
+            w[offset+i], w[offset+j] = w[offset+j], w[offset+i]
         end
         v[j], v[lo] = pivot, v[j]
-        w[j], w[lo] = w_piv, w[j]
+        w[offset+j], w[offset+lo] = w_piv, w[offset+j]
 
         # v[j] == pivot
         # v[k] >= pivot for k > j
@@ -119,19 +123,22 @@ module util
 
 
     # adapted from the Julia Base.Sort Library
+    # adapted from the Julia Base.Sort Library
+    # this sorts v[lo:hi] and w[offset+lo, offset+hi]
+    # simultaneously by the values in v[lo:hi]
     const SMALL_THRESHOLD  = 20
-    function q_bi_sort!(v, w, lo, hi)
+    function q_bi_sort!(v, w, lo, hi, offset)
         @inbounds while lo < hi
-            hi-lo <= SMALL_THRESHOLD && return insert_sort!(v, w, lo, hi)
-            j = _bi_partition!(v, w, lo, hi)
+            hi-lo <= SMALL_THRESHOLD && return insert_sort!(v, w, lo, hi, offset)
+            j = _bi_partition!(v, w, lo, hi, offset)
             if j-lo < hi-j
                 # recurse on the smaller chunk
                 # this is necessary to preserve O(log(n))
                 # stack space in the worst case (rather than O(n))
-                lo < (j-1) && q_bi_sort!(v, w, lo, j-1)
+                lo < (j-1) && q_bi_sort!(v, w, lo, j-1, offset)
                 lo = j+1
             else
-                j+1 < hi && q_bi_sort!(v, w, j+1, hi)
+                j+1 < hi && q_bi_sort!(v, w, j+1, hi, offset)
                 hi = j-1
             end
         end

--- a/test/bench/trees.jl
+++ b/test/bench/trees.jl
@@ -1,47 +1,45 @@
 
+let
 
-include("../../src/DecisionTree.jl")
-
-function loaddata()
-    f = open("data/digits.csv")
-    data = readlines(f)[2:end]
-    data = [[parse(Float32, i) 
-        for i in split(row, ",")]
-        for row in data]
-    data = hcat(data...)
-    Y = Int.(data[1, 1:end]) .+ 1
-    X = convert(Matrix, transpose(data[2:end, 1:end]))
-    return X, Y
-end
-
-num_leaves(node::DecisionTree.Node) = num_leaves(node.left) + num_leaves(node.right)
-num_leaves(node::DecisionTree.Leaf) = 1
-
-X, Y = loaddata()
-
-# for compilation
-for i in 1:10
-    t = DecisionTree.build_tree(Y, X)
-end
-
-println("[ === CLASSIFICATION BENCHMARK === ]")
-for j in 1:3
-    @time for i in 1:100
-        tree = DecisionTree.build_tree(Y, X)
+    function loaddata()
+        f = open("data/digits.csv")
+        data = readlines(f)[2:end]
+        data = [[parse(Float32, i)
+            for i in split(row, ",")]
+            for row in data]
+        data = hcat(data...)
+        Y = Int.(data[1, 1:end]) .+ 1
+        X = convert(Matrix, transpose(data[2:end, 1:end]))
+        return X, Y
     end
-end
 
+    X, Y = loaddata()
 
-Y = float.(Y) # labels/targets to Float to enable regression
-
-# for compilation
-for i in 1:10
-    t = DecisionTree.build_tree(Y, X)
-end
-
-println("[ === REGRESSION BENCHMARK === ]")
-for j in 1:3
-    @time for i in 1:100
-        tree = DecisionTree.build_tree(Y, X)
+    # for compilation
+    for i in 1:10
+        t = DecisionTree.build_tree(Y, X)
     end
+
+    println("[ === CLASSIFICATION BENCHMARK === ]")
+    for j in 1:3
+        @time for i in 1:100
+            tree = DecisionTree.build_tree(Y, X)
+        end
+    end
+
+
+    Y = float.(Y) # labels/targets to Float to enable regression
+
+    # for compilation
+    for i in 1:10
+        t = DecisionTree.build_tree(Y, X)
+    end
+
+    println("[ === REGRESSION BENCHMARK === ]")
+    for j in 1:3
+        @time for i in 1:100
+            tree = DecisionTree.build_tree(Y, X)
+        end
+    end
+
 end

--- a/test/classification/digits.jl
+++ b/test/classification/digits.jl
@@ -3,7 +3,7 @@
 function loaddata()
     f = open("data/digits.csv")
     data = readlines(f)[2:end]
-    data = [[parse(Float32, i) 
+    data = [[parse(Float32, i)
         for i in split(row, ",")]
         for row in data]
     data = hcat(data...)
@@ -12,25 +12,22 @@ function loaddata()
     return X, Y
 end
 
-num_leaves(node::DecisionTree.Node) = num_leaves(node.left) + num_leaves(node.right)
-num_leaves(node::DecisionTree.Leaf) = 1
-
 X, Y = loaddata()
 
 t = DecisionTree.build_tree(Y, X)
-@test num_leaves(t) == 148
+@test length(t) == 148
 @test sum(apply_tree(t, X) .== Y) == length(Y)
 
 t = DecisionTree.build_tree(Y, X, 0, 6)
-@test num_leaves(t) == 57
+@test length(t) == 57
 
 t = DecisionTree.build_tree(Y, X, 0, 6, 5)
-@test num_leaves(t) == 50
+@test length(t) == 50
 
 t = DecisionTree.build_tree(Y, X, 0, 6, 3, 5)
-@test num_leaves(t) == 55
+@test length(t) == 55
 
 t = DecisionTree.build_tree(Y, X, 0, 6, 3, 5, 0.05)
-@test num_leaves(t) == 54
+@test length(t) == 54
 
 end # @testset

--- a/test/classification/scikitlearn.jl
+++ b/test/classification/scikitlearn.jl
@@ -6,7 +6,7 @@ features = rand(n,m);
 weights = rand(-1:1,m);
 labels = _int(features * weights);
 
-# I wish we could use ScikitLearn.jl's cross-validation, but that'd require 
+# I wish we could use ScikitLearn.jl's cross-validation, but that'd require
 # installing it on Travis
 model = fit!(DecisionTreeClassifier(pruning_purity_threshold=0.9), features, labels)
 @test mean(predict(model, features) .== labels) > 0.8

--- a/test/regression/digits.jl
+++ b/test/regression/digits.jl
@@ -3,7 +3,7 @@
 function loaddata()
     f = open("data/digits.csv")
     data = readlines(f)[2:end]
-    data = [[parse(Float32, i) 
+    data = [[parse(Float32, i)
         for i in split(row, ",")]
         for row in data]
     data = hcat(data...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,9 +41,6 @@ test_suites = [
     ("Miscellaneous", miscellaneous),
 ]
 
-include("bench/trees.jl")
-
-
 @testset "Test Suites" begin
     for ts in 1:length(test_suites)
         name = test_suites[ts][1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,13 @@
-include("../src/DecisionTree.jl")
 using ScikitLearnBase
-using Main.DecisionTree
+using DecisionTree
 using Test
 
 import Distributed
 import Random
+
+function mean(xs)
+    return sum(xs) / length(xs)
+end
 
 function run_tests(list)
     for test in list

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
+include("../src/DecisionTree.jl")
 using ScikitLearnBase
-using DecisionTree
+using Main.DecisionTree
 using Test
 
 import Distributed
@@ -34,15 +35,21 @@ miscellaneous =  [
 test_suites = [
     ("Classification", classification),
     ("Regression", regression),
-    ("Miscellaneous", miscellaneous)
+    ("Miscellaneous", miscellaneous),
 ]
+
+include("bench/trees.jl")
+
 
 @testset "Test Suites" begin
     for ts in 1:length(test_suites)
         name = test_suites[ts][1]
         list = test_suites[ts][2]
-        @testset "$name" begin
-            run_tests(list)
+        let
+            @testset "$name" begin
+                run_tests(list)
+            end
         end
     end
 end
+


### PR DESCRIPTION
- minor style fixes
- now internally support weights! (though API is not yet exposed)
- now internally support passing purity criteria! (though API is not yet exposed)
- add `treeclassifier.fit_zero_one` for fitting with zero one loss
- classification's `build_stump` now calls `treeclassifier.fit_zero_one` internally.
- small (~2-3%) performance increase for classification's `build_tree`, despite new internal support for weights due to type optimisations.
- moderate (~9%) performance degradation for regression's `build_tree` due to internal support for weights. We do not expect this much degradation for adding a feature ever again.
- added type parameters to `NodeMeta` to help optimise memory usage.

Memory optimisations for writing to disk will follow soon.