### PR TITLE
Misc small fixes in tree.jl files

### DIFF
--- a/src/classification/tree.jl
+++ b/src/classification/tree.jl
@@ -196,9 +196,8 @@ module treeclassifier
             node.is_leaf = true
             return
         else
-            bf = Int(best_feature)
             @simd for i in 1:n_samples
-                Xf[i] = X[indX[i + r_start], bf]
+                Xf[i] = X[indX[i + r_start], best_feature]
             end
 
             try

--- a/src/regression/tree.jl
+++ b/src/regression/tree.jl
@@ -273,7 +273,7 @@ module treeregressor
         Xf  = Array{S}(undef, n_samples)
         Wf  = Array{U}(undef, n_samples)
 
-        indX = collect(Int(1):Int(n_samples))
+        indX = collect(1:n_samples)
         root = NodeMeta{S}(collect(1:n_features), 1:n_samples, 0)
         stack = NodeMeta{S}[root]
 

--- a/src/regression/tree.jl
+++ b/src/regression/tree.jl
@@ -239,7 +239,7 @@ module treeregressor
         if length(Y) != n_samples
             throw("dimension mismatch between X and Y ($(size(X)) vs $(size(Y))")
         elseif length(W) != n_samples
-            throw("dimension mismatch between X and W ($(size(X)) vs $(size(Y))")
+            throw("dimension mismatch between X and W ($(size(X)) vs $(size(W))")
         elseif max_depth < -1
             throw("unexpected value for max_depth: $(max_depth) (expected:"
                 * " max_depth >= 0, or max_depth = -1 for infinite depth)")

--- a/src/regression/tree.jl
+++ b/src/regression/tree.jl
@@ -196,7 +196,6 @@ module treeregressor
             return
         else
             # new_purity - old_purity < stop.min_purity_increase
-            bf = Int(best_feature)
             @simd for i in 1:n_samples
                 Xf[i] = X[indX[i + r_start], best_feature]
             end


### PR DESCRIPTION
In `src/regression/tree.jl`:
- Removed unused variable
- Fixed typo, changing `Y` to `W`

In both `src/classification/tree.jl` and `src/regression/tree.jl`:
- Removed a few `Int()`s. Based on what they were used on (and the fact that the unused variable above wasn't causing issues), it seemed like these were unnecessary.