### PR TITLE
Remove fit_zero_one?

### DIFF
--- a/src/classification/main.jl
+++ b/src/classification/main.jl
@@ -56,10 +56,11 @@ function build_stump(
         weights      = nothing;
         rng          = Random.GLOBAL_RNG) where {S, T}
 
-    t = treeclassifier.fit_zero_one(
+    t = treeclassifier.fit(
         X                   = features,
         Y                   = labels,
         W                   = weights,
+        loss                = treeclassifier.util.zero_one,
         max_features        = size(features, 2),
         max_depth           = 1,
         min_samples_leaf    = 1,

--- a/src/classification/tree.jl
+++ b/src/classification/tree.jl
@@ -8,7 +8,7 @@ module treeclassifier
     include("../util.jl")
     import Random
 
-    export fit, fit_zero_one
+    export fit
 
     mutable struct NodeMeta{S}
         l           :: NodeMeta{S}      # right child
@@ -344,44 +344,4 @@ module treeclassifier
 
         return Tree{S, T}(root, list, indX)
     end
-
-    function fit_zero_one(;
-            X                     :: Matrix{S},
-            Y                     :: Vector{T},
-            W                     :: Union{Nothing, Vector{U}},
-            max_features          :: Int,
-            max_depth             :: Int,
-            min_samples_leaf      :: Int,
-            min_samples_split     :: Int,
-            min_purity_increase   :: Float64,
-            rng=Random.GLOBAL_RNG :: Random.AbstractRNG) where {S, T, U}
-
-        n_samples, n_features = size(X)
-        list, Y_ = util.assign(Y)
-        if W == nothing
-            W = fill(1.0, n_samples)
-        end
-
-        check_input(
-            X, Y, W,
-            max_features,
-            max_depth,
-            min_samples_leaf,
-            min_samples_split,
-            min_purity_increase)
-
-        root, indX = _fit(
-            X, Y_, W,
-            util.zero_one,
-            length(list),
-            max_features,
-            max_depth,
-            min_samples_leaf,
-            min_samples_split,
-            min_purity_increase,
-            rng)
-
-        return Tree{S, T}(root, list, indX)
-    end
-
 end


### PR DESCRIPTION
`treeclassifier.fit_zero_one` seems to only differ from `treeclassifier.fit` by having a fixed loss function, and seems to only be used once, in `build_stump`. Can it be removed and have `build_stump` call `fit`, as done here, or is `fit_zero_one` being kept for other purposes?