### PR TITLE
Replace leftover util.entropy

### DIFF
--- a/src/classification/tree.jl
+++ b/src/classification/tree.jl
@@ -192,7 +192,7 @@ module treeclassifier
 
         # no splits honor min_samples_leaf
         @inbounds if (unsplittable
-            || (best_purity / nt + util.entropy(nc, nt) < min_purity_increase))
+            || (best_purity / nt + purity_function(nc, nt) < min_purity_increase))
             node.is_leaf = true
             return
         else

--- a/test/classification/digits.jl
+++ b/test/classification/digits.jl
@@ -39,6 +39,21 @@ t = DecisionTree.build_tree(
         min_purity_increase)
 @test length(t) == 54
 
+# test that all purity decisions are based on passed-in purity function;
+# if so, this should be same as previous test
+entropy1000(ns, n) = DecisionTree.util.entropy(ns, n) * 1000
+min_samples_leaf    = 3
+min_samples_split   = 5
+min_purity_increase = 0.05 * 1000
+t = DecisionTree.build_tree(
+        Y, X,
+        n_subfeatures, max_depth,
+        min_samples_leaf,
+        min_samples_split,
+        min_purity_increase,
+        loss = entropy1000)
+@test length(t) == 54
+
 n_subfeatures       = 3
 n_trees             = 10
 partial_sampling    = 0.7


### PR DESCRIPTION
It looks like the classification code was generalized to allow a passed-in <s>loss</s> purity function in [this commit](https://github.com/bensadeghi/DecisionTree.jl/commit/7c40a297829c055e57c6f76d4215227f4fcba66b). However, one `util.entropy` was left in the code. It looks like that should have also been replaced. This PR replaces it, and adds a test. The test gives depth = 1 (i.e., fails) before replacing the `util.entropy`.