### PR TITLE
Add tolerance for best_purity checks

### DIFF
--- a/src/classification/tree.jl
+++ b/src/classification/tree.jl
@@ -148,7 +148,7 @@ module treeclassifier
                     unsplittable = false
                     purity = -(nl * purity_function(ncl, nl)
                              + nr * purity_function(ncr, nr))
-                    if purity > best_purity
+                    if purity > best_purity + 1e-12
                         # will take average at the end
                         threshold_lo = last_f
                         threshold_hi = curr_f

--- a/src/regression/tree.jl
+++ b/src/regression/tree.jl
@@ -148,7 +148,7 @@ module treeregressor
                 if lo-1 >= min_samples_leaf && n_samples - (lo-1) >= min_samples_leaf
                     unsplittable = false
                     purity = (rsum * rsum / nr) + (lsum * lsum / nl)
-                    if purity > best_purity
+                    if purity > best_purity + 1e-12
                         # will take average at the end, if possible
                         threshold_lo = last_f
                         threshold_hi = curr_f


### PR DESCRIPTION
I found that I was getting different results for the same problem with the same RNG across different Julia versions (even after accounting for the RNG changes in Julia 1.5). 

The differences seem to show up when there are multiple features with the same best split position, but because of differences between the Julia versions, the actual purity values are slightly different in the last digits, e.g. `9.893954468378139` vs `9.893954468378137`, and this causes different features to be chosen on each version.

This change simply adds a small tolerance to the purity check, which ensures that changes in the last digits won't affect which feature is selected as best.