### PR TITLE
Fix #119 to work regardless of data scaling

### DIFF
--- a/src/classification/tree.jl
+++ b/src/classification/tree.jl
@@ -148,7 +148,7 @@ module treeclassifier
                     unsplittable = false
                     purity = -(nl * purity_function(ncl, nl)
                              + nr * purity_function(ncr, nr))
-                    if purity > best_purity + 1e-12
+                    if purity > best_purity && !isapprox(purity, best_purity)
                         # will take average at the end
                         threshold_lo = last_f
                         threshold_hi = curr_f

--- a/src/regression/tree.jl
+++ b/src/regression/tree.jl
@@ -148,7 +148,7 @@ module treeregressor
                 if lo-1 >= min_samples_leaf && n_samples - (lo-1) >= min_samples_leaf
                     unsplittable = false
                     purity = (rsum * rsum / nr) + (lsum * lsum / nl)
-                    if purity > best_purity + 1e-12
+                    if purity > best_purity && !isapprox(purity, best_purity)
                         # will take average at the end, if possible
                         threshold_lo = last_f
                         threshold_hi = curr_f


### PR DESCRIPTION
Thanks so much for the fast merge on #119  

I missed that the added check is not robust to the scaling of the data. This fixes that by using `isapprox` rather than an absolute tolerance, so it should work consistently across inputs.

Sorry for the noise and missing this, and thanks again!