### PR TITLE
Allow fitting using AbstractMatrix instead of Matrix

### DIFF
--- a/src/classification/tree.jl
+++ b/src/classification/tree.jl
@@ -257,7 +257,7 @@ module treeclassifier
     end
 
     function _fit(
-            X                     :: Matrix{S},
+            X                     :: AbstractMatrix{S},
             Y                     :: AbstractVector{Int},
             W                     :: AbstractVector{U},
             loss                  :: Function,
@@ -304,7 +304,7 @@ module treeclassifier
     end
 
     function fit(;
-            X                     :: Matrix{S},
+            X                     :: AbstractMatrix{S},
             Y                     :: AbstractVector{T},
             W                     :: Union{Nothing, AbstractVector{U}},
             loss=util.entropy     :: Function,

--- a/src/regression/tree.jl
+++ b/src/regression/tree.jl
@@ -260,7 +260,7 @@ module treeregressor
     end
 
     function _fit(
-            X                     :: Matrix{S},
+            X                     :: AbstractMatrix{S},
             Y                     :: AbstractVector{Float64},
             W                     :: AbstractVector{U},
             max_features          :: Int,
@@ -303,7 +303,7 @@ module treeregressor
     end
 
     function fit(;
-            X                     :: Matrix{S},
+            X                     :: AbstractMatrix{S},
             Y                     :: AbstractVector{Float64},
             W                     :: Union{Nothing, AbstractVector{U}},
             max_features          :: Int,


### PR DESCRIPTION
This PR follows #128 and changes `Matrix` to `AbstractMatrix` in other places that were missed in the original PR.