### PR TITLE
Move `check_input` to utils to avoid duplicate code

### DIFF
--- a/src/classification/tree.jl
+++ b/src/classification/tree.jl
@@ -225,37 +225,6 @@ module treeclassifier
         node.r = NodeMeta{S}(features, region[ind+1:end], node.depth+1)
     end
 
-    function check_input(
-            X                   :: AbstractMatrix{S},
-            Y                   :: AbstractVector{T},
-            W                   :: AbstractVector{U},
-            max_features        :: Int,
-            max_depth           :: Int,
-            min_samples_leaf    :: Int,
-            min_samples_split   :: Int,
-            min_purity_increase :: Float64) where {S, T, U}
-        n_samples, n_features = size(X)
-        if length(Y) != n_samples
-            throw("dimension mismatch between X and Y ($(size(X)) vs $(size(Y))")
-        elseif length(W) != n_samples
-            throw("dimension mismatch between X and W ($(size(X)) vs $(size(W))")
-        elseif max_depth < -1
-            throw("unexpected value for max_depth: $(max_depth) (expected:"
-                * " max_depth >= 0, or max_depth = -1 for infinite depth)")
-        elseif n_features < max_features
-            throw("number of features $(n_features) is less than the number "
-                * "of max features $(max_features)")
-        elseif max_features < 0
-            throw("number of features $(max_features) must be >= zero ")
-        elseif min_samples_leaf < 1
-            throw("min_samples_leaf must be a positive integer "
-                * "(given $(min_samples_leaf))")
-        elseif min_samples_split < 2
-            throw("min_samples_split must be at least 2 "
-                * "(given $(min_samples_split))")
-        end
-    end
-
     function _fit(
             X                     :: AbstractMatrix{S},
             Y                     :: AbstractVector{Int},
@@ -321,7 +290,7 @@ module treeclassifier
             W = fill(1, n_samples)
         end
 
-        check_input(
+        util.check_input(
             X, Y, W,
             max_features,
             max_depth,

--- a/src/regression/tree.jl
+++ b/src/regression/tree.jl
@@ -228,37 +228,6 @@ module treeregressor
         node.r = NodeMeta{S}(features, region[ind+1:end], node.depth + 1)
     end
 
-    function check_input(
-            X                   :: AbstractMatrix{S},
-            Y                   :: AbstractVector{T},
-            W                   :: AbstractVector{U},
-            max_features        :: Int,
-            max_depth           :: Int,
-            min_samples_leaf    :: Int,
-            min_samples_split   :: Int,
-            min_purity_increase :: Float64) where {S, T, U}
-        n_samples, n_features = size(X)
-        if length(Y) != n_samples
-            throw("dimension mismatch between X and Y ($(size(X)) vs $(size(Y))")
-        elseif length(W) != n_samples
-            throw("dimension mismatch between X and W ($(size(X)) vs $(size(W))")
-        elseif max_depth < -1
-            throw("unexpected value for max_depth: $(max_depth) (expected:"
-                * " max_depth >= 0, or max_depth = -1 for infinite depth)")
-        elseif n_features < max_features
-            throw("number of features $(n_features) is less than the number "
-                * "of max features $(max_features)")
-        elseif max_features < 0
-            throw("number of features $(max_features) must be >= zero ")
-        elseif min_samples_leaf < 1
-            throw("min_samples_leaf must be a positive integer "
-                * "(given $(min_samples_leaf))")
-        elseif min_samples_split < 2
-            throw("min_samples_split must be at least 2 "
-                * "(given $(min_samples_split))")
-        end
-    end
-
     function _fit(
             X                     :: AbstractMatrix{S},
             Y                     :: AbstractVector{Float64},
@@ -318,7 +287,7 @@ module treeregressor
             W = fill(1.0, n_samples)
         end
 
-        check_input(
+        util.check_input(
             X,
             Y,
             W,

--- a/src/util.jl
+++ b/src/util.jl
@@ -3,7 +3,7 @@
 
 module util
 
-    export gini, entropy, zero_one, q_bi_sort!, hypergeometric
+    export gini, entropy, zero_one, q_bi_sort!, hypergeometric, check_input
 
     function assign(Y :: AbstractVector{T}, list :: AbstractVector{T}) where T
         dict = Dict{T, Int}()
@@ -294,6 +294,37 @@ module util
             hypergeometric_hrua(good, bad, sample)
         else
             hypergeometric_hyp(good, bad, sample)
+        end
+    end
+
+    function check_input(
+            X                   :: AbstractMatrix{S},
+            Y                   :: AbstractVector{T},
+            W                   :: AbstractVector{U},
+            max_features        :: Int,
+            max_depth           :: Int,
+            min_samples_leaf    :: Int,
+            min_samples_split   :: Int,
+            min_purity_increase :: Float64) where {S, T, U}
+        n_samples, n_features = size(X)
+        if length(Y) != n_samples
+            throw("dimension mismatch between X and Y ($(size(X)) vs $(size(Y))")
+        elseif length(W) != n_samples
+            throw("dimension mismatch between X and W ($(size(X)) vs $(size(W))")
+        elseif max_depth < -1
+            throw("unexpected value for max_depth: $(max_depth) (expected:"
+                * " max_depth >= 0, or max_depth = -1 for infinite depth)")
+        elseif n_features < max_features
+            throw("number of features $(n_features) is less than the number "
+                * "of max features $(max_features)")
+        elseif max_features < 0
+            throw("number of features $(max_features) must be >= zero ")
+        elseif min_samples_leaf < 1
+            throw("min_samples_leaf must be a positive integer "
+                * "(given $(min_samples_leaf))")
+        elseif min_samples_split < 2
+            throw("min_samples_split must be at least 2 "
+                * "(given $(min_samples_split))")
         end
     end
 


### PR DESCRIPTION
The `check_input` function tests if the given tree hyper-parameters are valid. Before this PR, the function was present in both classification and regression code. This PR removes the duplicate code by moving the function to `utils.jl`.